### PR TITLE
feat: add pytorch-lightning

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -6,5 +6,6 @@ build:
     - "transformers==4.25.1"
     - "accelerate==0.15.0"
     - "omegaconf==2.3.0"
-  
+    - "pytorch-lightning==2.0.1"
+
 predict: "predict.py:Predictor"


### PR DESCRIPTION
Using:
  * repo_id: `nitrosocke/Arcane-Diffusion`
  * ckpt_file: `arcane-diffusion-5k.ckpt`

Results in:
```
Traceback (most recent call last):
File "/usr/local/lib/python3.10/site-packages/cog/server/worker.py", line 217, in _predict
result = predict(**payload)
File "/src/predict.py", line 101, in predict
self.download_repo(repo_id=repo_id, revision=revision, ckpt_file=ckpt_file, dest=weights_dir, float16=force_float16)
File "/src/predict.py", line 63, in download_repo
pipe = load_ckpt(local_ckpt_file)
File "/src/predict.py", line 41, in load_ckpt
return load_pipeline_from_original_stable_diffusion_ckpt(
File "/usr/local/lib/python3.10/site-packages/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py", line 1035, in load_pipeline_from_original_stable_diffusion_ckpt
checkpoint = torch.load(checkpoint_path, map_location=device)
File "/usr/local/lib/python3.10/site-packages/torch/serialization.py", line 789, in load
return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
File "/usr/local/lib/python3.10/site-packages/torch/serialization.py", line 1131, in _load
result = unpickler.load()
File "/usr/local/lib/python3.10/site-packages/torch/serialization.py", line 1124, in find_class
return super().find_class(mod_name, name)
ModuleNotFoundError: No module named 'pytorch_lightning'
```

___

Add missing module in hopes if fixing it.